### PR TITLE
Build for CommonJS and push type definition

### DIFF
--- a/packages/monaco-util/package.json
+++ b/packages/monaco-util/package.json
@@ -19,14 +19,19 @@
     "locales",
     "i18n"
   ],
-  "main": "dist/index.js",
+  "exports": {
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs"
+  },
   "types": "dist/index.d.ts",
   "files": [
     "dist/index.js",
+    "dist/index.cjs",
+    "dist/index.d.ts",
     "locales"
   ],
   "scripts": {
-    "build:code": "echo 'Building code...' && tsc -p ./tsconfig.build.json",
+    "build:code": "echo 'Building code...' && tsc -p ./tsconfig.build.json --module commonjs && mv ./dist/index.js ./dist/index.cjs && tsc -p ./tsconfig.build.json",
     "build:locales": "echo 'Building locales...' && node ./src/scripts/get-locale-diagnostic-messages.js",
     "build": "npm run build:code && npm run build:locales",
     "prepublish:base": "echo 'Making sure TypeScript is up to date...' && yarn up typescript && yarn --top-level run lint && npm run build",


### PR DESCRIPTION
This PR should fix #4 by:

- conditional exporting for commonjs and esm
- including `index.d.ts` file

Please let me know if the `build --module commonjs` + `rename` + `build` approach is suboptimal.